### PR TITLE
try removing the relative "here" path matching

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
     "npm"
   ],
   "devcontainer": {
-    "fileMatch": ["^./src/sm-operator/.devcontainer/common/devcontainer.json$"]
+    "fileMatch": ["^src/sm-operator/.devcontainer/common/devcontainer.json$"]
   },
   "packageRules": [
     {


### PR DESCRIPTION
## 🚧 Type of change

- 🧹 Tech debt (refactoring, code cleanup, dependency upgrades, etc.)

## 📔 Objective

Attempt to fix Renovate not matching the devcontainer path.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
