### PR TITLE
bre-942/update-dockerfile-to-alpine-builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as builder
+FROM golang:1.21-alpine3.20 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -15,11 +15,11 @@ COPY api/ api/
 COPY internal/controller/ internal/controller/
 COPY Makefile Makefile
 
-RUN apt update && apt install unzip musl-tools -y
+RUN apk add --no-cache unzip musl-dev build-base
 
 RUN mkdir state
 
-RUN CC=musl-gcc CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags '-linkmode external -extldflags "-static -Wl,-unresolved-symbols=ignore-all"' -o manager cmd/main.go
+RUN CC=gcc CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags '-linkmode external -extldflags "-static -Wl,-unresolved-symbols=ignore-all"' -o manager cmd/main.go
 
 FROM gcr.io/distroless/base-debian12:nonroot
 WORKDIR /


### PR DESCRIPTION
## 🎟️ Tracking
[BRE-915](https://bitwarden.atlassian.net/browse/BRE-915) has the most detail, BRE-942 is a subtask for tracking the file change

## 📔 Objective
update the builder stage to use an alpine based image to increase security. switched apt package manager commands to apk

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes


[BRE-915]: https://bitwarden.atlassian.net/browse/BRE-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ