### PR TITLE
Feature: Allow loading auth tokens from external namespace

### DIFF
--- a/.github/workflows/build-ghcr.yml
+++ b/.github/workflows/build-ghcr.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  packages: read
+  packages: write
 
 jobs:
   build-docker:

--- a/.github/workflows/build-ghcr.yml
+++ b/.github/workflows/build-ghcr.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build Docker images
     runs-on: ubuntu-22.04
     env:
-      _GHCR_REGISTRY: ghcr.io/bitwarden
+      _GHCR_REGISTRY: ghcr.io/${{github.repository_owner}}
       _PROJECT_NAME: sm-operator
 
     steps:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   check-run:
     name: Check PR run
+    if: github.repository == 'bitwarden/sm-kubernetes'
     uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
 
   sast:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 as builder
+FROM golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/api/v1/bitwardensecret_types.go
+++ b/api/v1/bitwardensecret_types.go
@@ -60,6 +60,9 @@ type AuthToken struct {
 	// The key of the Kubernetes secret where the authorization token is stored
 	// +kubebuilder:Required
 	SecretKey string `json:"secretKey"`
+	// The namespace where the authorization token secret is stored. If not specified, defaults to the same namespace as the BitwardenSecret
+	// +kubebuilder:Optional
+	Namespace string `json:"namespace,omitempty"`
 }
 
 type SecretMap struct {

--- a/config/crd/bases/k8s.bitwarden.com_bitwardensecrets.yaml
+++ b/config/crd/bases/k8s.bitwarden.com_bitwardensecrets.yaml
@@ -43,6 +43,11 @@ spec:
                 description: The secret key reference for the authorization token
                   used to connect to Secrets Manager
                 properties:
+                  namespace:
+                    description: The namespace where the authorization token secret
+                      is stored. If not specified, defaults to the same namespace
+                      as the BitwardenSecret
+                    type: string
                   secretKey:
                     description: The key of the Kubernetes secret where the authorization
                       token is stored

--- a/internal/controller/test/testutils/fixture.go
+++ b/internal/controller/test/testutils/fixture.go
@@ -219,6 +219,10 @@ func (f *TestFixture) CreateDefaultBitwardenSecret(namespace string, secretMap [
 }
 
 func (f *TestFixture) CreateBitwardenSecret(name, namespace, orgID, secretName, authSecretName, authSecretKey string, secretMap []operatorsv1.SecretMap, onlyMappedSecrets bool) (*operatorsv1.BitwardenSecret, error) {
+	return f.CreateBitwardenSecretWithAuthNamespace(name, namespace, orgID, secretName, authSecretName, authSecretKey, "", secretMap, onlyMappedSecrets)
+}
+
+func (f *TestFixture) CreateBitwardenSecretWithAuthNamespace(name, namespace, orgID, secretName, authSecretName, authSecretKey, authNamespace string, secretMap []operatorsv1.SecretMap, onlyMappedSecrets bool) (*operatorsv1.BitwardenSecret, error) {
 	bwSecret := &operatorsv1.BitwardenSecret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -228,6 +232,7 @@ func (f *TestFixture) CreateBitwardenSecret(name, namespace, orgID, secretName, 
 			AuthToken: operatorsv1.AuthToken{
 				SecretName: authSecretName,
 				SecretKey:  authSecretKey,
+				Namespace:  authNamespace,
 			},
 			SecretName:        secretName,
 			OrganizationId:    orgID,


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/sm-kubernetes/issues/47
https://github.com/bitwarden/sm-kubernetes/pull/94

## 📔 Objective

This implements an optional parameter `namespace` in AuthToken that allows for fetching the token from an external namespace than the one the BitwardenSecret is currently in.

In addition to this, I have made small changes to the GitHub Actions workflows so that they build, or are appropriately skipped on forked branches.
One of those was caused by adding the default permissions to the workflow as read. We need the GITHUB_SECRET to have `write` permissions in order to publish new packages to the org.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
