### PR TITLE
[PM-33388] Fix BitwardenSecret controller not re-syncing secrets periodically

### DIFF
--- a/internal/controller/bitwardensecret_controller.go
+++ b/internal/controller/bitwardensecret_controller.go
@@ -99,9 +99,15 @@ func (r *BitwardenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	lastSync := bwSecret.Status.LastSuccessfulSyncTime
+	nextSync := lastSync.Time.Add(time.Duration(r.RefreshIntervalSeconds) * time.Second)
 
-	if !lastSync.IsZero() && time.Now().UTC().Before(lastSync.Time.Add(time.Duration(r.RefreshIntervalSeconds)*time.Second)) {
-		return ctrl.Result{}, nil
+	if !lastSync.IsZero() && time.Now().UTC().Before(nextSync) {
+		remaining := time.Until(nextSync)
+		logger.Info(fmt.Sprintf("Skipping sync for %s/%s — last sync was %s, next sync in %s",
+			req.NamespacedName.Namespace, req.Name, lastSync.Time.Format("15:04:05"), remaining.Round(time.Second)))
+		return ctrl.Result{
+			RequeueAfter: remaining,
+		}, nil
 	}
 
 	message := fmt.Sprintf("Syncing  %s/%s", req.NamespacedName.Namespace, req.Name)

--- a/internal/controller/test/reconciler_success_test.go
+++ b/internal/controller/test/reconciler_success_test.go
@@ -78,43 +78,29 @@ var _ = Describe("BitwardenSecret Reconciler - Success Tests", Ordered, func() {
 		}).Should(Succeed())
 	})
 
-	// //This test misbehaves with the following error.  There's no rational reason for this to happen, so we'll leave it to the
-	// //end user to figure out if this test is relevant to their needs.
-	// //Message: "Operation cannot be fulfilled on bitwardensecrets.k8s.bitwarden.com \"bw-secret\": the object has been modified; please apply your changes to the latest version and try again",
-	// It("should skip reconciliation when last sync is within refresh interval", func() {
-	// 	fixture.SetupDefaultCtrlMocks(false, nil)
+	It("should skip reconciliation when last sync is within refresh interval", func() {
+		fixture.SetupDefaultCtrlMocks(false, nil)
 
-	// 	_, err := fixture.CreateDefaultAuthSecret(namespace)
-	// 	Expect(err).NotTo(HaveOccurred())
+		_, err := fixture.CreateDefaultAuthSecret(namespace)
+		Expect(err).NotTo(HaveOccurred())
 
-	// 	bwSecret, err := fixture.CreateDefaultBitwardenSecret(namespace, fixture.SecretMap)
-	// 	Expect(err).NotTo(HaveOccurred())
-	// 	Expect(bwSecret).NotTo(BeNil())
+		_, err = fixture.CreateDefaultBitwardenSecret(namespace, fixture.SecretMap)
+		Expect(err).NotTo(HaveOccurred())
 
-	// 	// Update status with LastSuccessfulSyncTime, retrying on conflicts
-	// 	syncTime := time.Now().UTC()
-	// 	Eventually(func(g Gomega) {
-	// 		// Fetch the latest version of bwSecret (use cached client for Get)
-	// 		latestBwSecret := &operatorsv1.BitwardenSecret{}
-	// 		err := fixture.K8sClient.Get(fixture.Ctx, types.NamespacedName{Name: testutils.BitwardenSecretName, Namespace: namespace}, latestBwSecret)
-	// 		GinkgoWriter.Printf("Fetched BitwardenSecret %s/%s, ResourceVersion: %s, err: %v\n", namespace, testutils.BitwardenSecretName, latestBwSecret.ResourceVersion, err)
-	// 		g.Expect(err).Should(Succeed())
+		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: testutils.BitwardenSecretName, Namespace: namespace}}
 
-	// 		// Update status
-	// 		latestBwSecret.Status = operatorsv1.BitwardenSecretStatus{
-	// 			LastSuccessfulSyncTime: metav1.Time{Time: syncTime},
-	// 		}
-	// 		err = fixture.K8sClient.Status().Update(fixture.Ctx, latestBwSecret)
-	// 		GinkgoWriter.Printf("Status update for %s/%s, ResourceVersion: %s, err: %v\n", namespace, testutils.BitwardenSecretName, latestBwSecret.ResourceVersion, err)
-	// 		g.Expect(err).Should(Succeed())
-	// 	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+		// First reconcile: performs the actual sync and sets LastSuccessfulSyncTime
+		result, err := fixture.Reconciler.Reconcile(fixture.Ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Duration(fixture.Reconciler.RefreshIntervalSeconds) * time.Second))
 
-	// 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: testutils.BitwardenSecretName, Namespace: namespace}}
-
-	// 	result, err := fixture.Reconciler.Reconcile(fixture.Ctx, req)
-	// 	Expect(err).NotTo(HaveOccurred())
-	// 	Expect(result).To(Equal(reconcile.Result{}))
-	// })
+		// Second reconcile: should skip because last sync is within refresh interval
+		result, err = fixture.Reconciler.Reconcile(fixture.Ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		fullInterval := time.Duration(fixture.Reconciler.RefreshIntervalSeconds) * time.Second
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+		Expect(result.RequeueAfter).To(BeNumerically("<=", fullInterval))
+	})
 
 	It("should skip sync when no changes from Bitwarden API", func() {
 		// Override mocks to return no changes


### PR DESCRIPTION
The early-return path in Reconcile (when the last sync is still within the refresh interval) returned an empty ctrl.Result{}, which meant controller-runtime never re-queued the resource. After the first successful sync, secrets were never synced again unless the BitwardenSecret CR was modified externally.

* Return ctrl.Result{RequeueAfter: remaining} where remaining is the time until the next sync is due, so the reconciler is reliably re-invoked at the configured refresh interval.

* Re-enable and rewrite the previously commented-out test to verify that the skip path returns a non-zero RequeueAfter. The new test avoids the original race condition by using two sequential reconciliations instead of manually updating the status.

After the fix the secrets get updated periodically:
```text
2026-03-11T10:58:07Z	INFO	Syncing  postgres/git-secret	{"controller": "bitwardensecret", "controllerGroup": "k8s.bitwarden.com", "controllerKind": "BitwardenSecret", "BitwardenSecret": {"name":"git-secret","namespace":"postgres"}, "namespace": "postgres", "name": "git-secret", "reconcileID": "dd9dfa77-bbb5-4b55-9a08-d805c4dc256a"}
2026-03-11T10:58:08Z	INFO	No changes to postgres/git-secret.  Skipping sync.	{"controller": "bitwardensecret", "controllerGroup": "k8s.bitwarden.com", "controllerKind": "BitwardenSecret", "BitwardenSecret": {"name":"git-secret","namespace":"postgres"}, "namespace": "postgres", "name": "git-secret", "reconcileID": "dd9dfa77-bbb5-4b55-9a08-d805c4dc256a"}
2026-03-11T10:58:08Z	INFO	Syncing  postgres/postgres-secret	{"controller": "bitwardensecret", "controllerGroup": "k8s.bitwarden.com", "controllerKind": "BitwardenSecret", "BitwardenSecret": {"name":"postgres-secret","namespace":"postgres"}, "namespace": "postgres", "name": "postgres-secret", "reconcileID": "8dab3b56-ad99-4871-a5d2-e39b2503ab89"}
2026-03-11T10:58:08Z	INFO	No changes to postgres/postgres-secret.  Skipping sync.	{"controller": "bitwardensecret", "controllerGroup": "k8s.bitwarden.com", "controllerKind": "BitwardenSecret", "BitwardenSecret": {"name":"postgres-secret","namespace":"postgres"}, "namespace": "postgres", "name": "postgres-secret", "reconcileID": "8dab3b56-ad99-4871-a5d2-e39b2503ab89"}
2026-03-11T11:01:08Z	INFO	Syncing  postgres/git-secret	{"controller": "bitwardensecret", "controllerGroup": "k8s.bitwarden.com", "controllerKind": "BitwardenSecret", "BitwardenSecret": {"name":"git-secret","namespace":"postgres"}, "namespace": "postgres", "name": "git-secret", "reconcileID": "0297ef82-06db-4302-ae1a-8ebcaa94023b"}
2026-03-11T11:01:08Z	INFO	Completed sync for postgres/git-secret	{"controller": "bitwardensecret", "controllerGroup": "k8s.bitwarden.com", "controllerKind": "BitwardenSecret", "BitwardenSecret": {"name":"git-secret","namespace":"postgres"}, "namespace": "postgres", "name": "git-secret", "reconcileID": "0297ef82-06db-4302-ae1a-8ebcaa94023b"}
2026-03-11T11:01:08Z	INFO	Syncing  postgres/postgres-secret	{"controller": "bitwardensecret", "controllerGroup": "k8s.bitwarden.com", "controllerKind": "BitwardenSecret", "BitwardenSecret": {"name":"postgres-secret","namespace":"postgres"}, "namespace": "postgres", "name": "postgres-secret", "reconcileID": "216fc445-70f1-4635-b318-febddc5fed3c"}
2026-03-11T11:01:09Z	INFO	Completed sync for postgres/postgres-secret	{"controller": "bitwardensecret", "controllerGroup": "k8s.bitwarden.com", "controllerKind": "BitwardenSecret", "BitwardenSecret": {"name":"postgres-secret","namespace":"postgres"}, "namespace": "postgres", "name": "postgres-secret", "reconcileID": "216fc445-70f1-4635-b318-febddc5fed3c"}
2026-03-11T11:01:09Z	INFO	Skipping sync for postgres/git-secret — last sync was 11:01:08, next sync in 2m59s	{"controller": "bitwardensecret", "controllerGroup": "k8s.bitwarden.com", "controllerKind": "BitwardenSecret", "BitwardenSecret": {"name":"git-secret","namespace":"postgres"}, "namespace": "postgres", "name": "git-secret", "reconcileID": "2e9c4834-1321-4efb-b64e-f91b59d93713"}
2026-03-11T11:01:09Z	INFO	Skipping sync for postgres/postgres-secret — last sync was 11:01:09, next sync in 3m0s	{"controller": "bitwardensecret", "controllerGroup": "k8s.bitwarden.com", "controllerKind": "BitwardenSecret", "BitwardenSecret": {"name":"postgres-secret","namespace":"postgres"}, "namespace": "postgres", "name": "postgres-secret", "reconcileID": "ef488df6-c475-4c6c-9808-8019c75b3881"}
```