### PR TITLE
[PM-35313] feat: add optional ProjectId field to filter secrets by Bitwarden project

### DIFF
--- a/api/v1/bitwardensecret_types.go
+++ b/api/v1/bitwardensecret_types.go
@@ -59,6 +59,10 @@ type BitwardenSecretSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	UseSecretNames bool `json:"useSecretNames,omitempty"`
+	// ProjectId, when set, filters the secrets synced from Bitwarden Secrets Manager to only those belonging
+	// to the specified project UUID. When unset, all secrets accessible by the machine account are synced.
+	// +kubebuilder:validation:Optional
+	ProjectId string `json:"projectId,omitempty"`
 }
 
 type AuthToken struct {

--- a/config/crd/bases/k8s.bitwarden.com_bitwardensecrets.yaml
+++ b/config/crd/bases/k8s.bitwarden.com_bitwardensecrets.yaml
@@ -88,6 +88,11 @@ spec:
                               organizationId:
                                   description: The organization ID for your organization
                                   type: string
+                              projectId:
+                                  description: |-
+                                      ProjectId, when set, filters the secrets synced from Bitwarden Secrets Manager to only those belonging
+                                      to the specified project UUID. When unset, all secrets accessible by the machine account are synced.
+                                  type: string
                               secretName:
                                   description: The name of the secret for the
                                   type: string

--- a/internal/controller/bitwardensecret_controller.go
+++ b/internal/controller/bitwardensecret_controller.go
@@ -135,7 +135,7 @@ func (r *BitwardenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	//Get the secrets from the Bitwarden API based on lastSync and organizationId
 	//This will also indicate if the Bitwarden secret needs to be refreshed
-	refresh, secrets, err := r.PullSecretManagerSecretDeltas(logger, orgId, authToken, lastSync.Time, bwSecret.Spec.UseSecretNames)
+	refresh, secrets, err := r.PullSecretManagerSecretDeltas(logger, orgId, authToken, lastSync.Time, bwSecret.Spec.UseSecretNames, bwSecret.Spec.ProjectId)
 
 	if err != nil {
 		logErr := r.LogError(logger, ctx, bwSecret, err, fmt.Sprintf("Error pulling Secret Manager secrets from API => API: %s -- Identity: %s -- State: %s -- OrgId: %s ", r.BitwardenClientFactory.GetApiUrl(), r.BitwardenClientFactory.GetIdentityApiUrl(), r.StatePath, orgId))
@@ -347,7 +347,7 @@ func ValidateSecretKeyName(key string) error {
 // This function will determine if any secrets have been updated and return all secrets assigned to the machine account if so.
 // First returned value is a boolean stating if something changed or not.
 // The second returned value is a mapping of secret IDs (or names if useSecretNames is true) and their values from Secrets Manager
-func (r *BitwardenSecretReconciler) PullSecretManagerSecretDeltas(logger logr.Logger, orgId string, authToken string, lastSync time.Time, useSecretNames bool) (bool, map[string][]byte, error) {
+func (r *BitwardenSecretReconciler) PullSecretManagerSecretDeltas(logger logr.Logger, orgId string, authToken string, lastSync time.Time, useSecretNames bool, projectId string) (bool, map[string][]byte, error) {
 	bitwardenClient, err := r.BitwardenClientFactory.GetBitwardenClient()
 	if err != nil {
 		logger.Error(err, "Failed to create client")
@@ -375,6 +375,17 @@ func (r *BitwardenSecretReconciler) PullSecretManagerSecretDeltas(logger logr.Lo
 	}
 
 	smSecretVals := smSecretResponse.Secrets
+
+	// Filter by project ID if specified
+	if projectId != "" {
+		filtered := smSecretVals[:0]
+		for _, s := range smSecretVals {
+			if s.ProjectID != nil && *s.ProjectID == projectId {
+				filtered = append(filtered, s)
+			}
+		}
+		smSecretVals = filtered
+	}
 
 	// Use UUIDs as keys
 	if !useSecretNames {

--- a/internal/controller/test/reconciler_project_filter_test.go
+++ b/internal/controller/test/reconciler_project_filter_test.go
@@ -1,0 +1,208 @@
+package controller_test
+
+import (
+	"time"
+
+	sdk "github.com/bitwarden/sdk-go/v2"
+	operatorsv1 "github.com/bitwarden/sm-kubernetes/api/v1"
+	"github.com/bitwarden/sm-kubernetes/internal/controller/test/testutils"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("BitwardenSecret Reconciler - Project ID Filter Tests", Ordered, func() {
+	var (
+		namespace       string
+		fixture         testutils.TestFixture
+		targetProjectId string
+	)
+
+	BeforeEach(func() {
+		fixture = *testutils.NewTestFixture(testContext, envTestRunner)
+		namespace = fixture.CreateNamespace()
+		targetProjectId = uuid.NewString()
+	})
+
+	AfterAll(func() {
+		fixture.Cancel()
+	})
+
+	AfterEach(func() {
+		fixture.Teardown()
+	})
+
+	It("should sync only secrets belonging to the specified project ID", func() {
+		otherProjectId := uuid.NewString()
+		secrets := []sdk.SecretResponse{
+			{ID: uuid.NewString(), Key: "secret_0", Value: "v0", OrganizationID: fixture.OrgId, ProjectID: &targetProjectId, CreationDate: time.Now(), RevisionDate: time.Now()},
+			{ID: uuid.NewString(), Key: "secret_1", Value: "v1", OrganizationID: fixture.OrgId, ProjectID: &targetProjectId, CreationDate: time.Now(), RevisionDate: time.Now()},
+			{ID: uuid.NewString(), Key: "secret_2", Value: "v2", OrganizationID: fixture.OrgId, ProjectID: &targetProjectId, CreationDate: time.Now(), RevisionDate: time.Now()},
+			{ID: uuid.NewString(), Key: "other_0", Value: "o0", OrganizationID: fixture.OrgId, ProjectID: &otherProjectId, CreationDate: time.Now(), RevisionDate: time.Now()},
+			{ID: uuid.NewString(), Key: "other_1", Value: "o1", OrganizationID: fixture.OrgId, ProjectID: &otherProjectId, CreationDate: time.Now(), RevisionDate: time.Now()},
+		}
+		fixture.SetupDefaultCtrlMocks(false, &sdk.SecretsSyncResponse{HasChanges: true, Secrets: secrets})
+
+		_, err := fixture.CreateDefaultAuthSecret(namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		bwSecret := &operatorsv1.BitwardenSecret{
+			ObjectMeta: metav1.ObjectMeta{Name: testutils.BitwardenSecretName, Namespace: namespace},
+			Spec: operatorsv1.BitwardenSecretSpec{
+				AuthToken:         operatorsv1.AuthToken{SecretName: testutils.AuthSecretName, SecretKey: testutils.AuthSecretKey},
+				SecretName:        testutils.SynchronizedSecretName,
+				OrganizationId:    fixture.OrgId,
+				OnlyMappedSecrets: false,
+				ProjectId:         targetProjectId,
+			},
+		}
+		Expect(fixture.K8sClient.Create(fixture.Ctx, bwSecret)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			fetched := &operatorsv1.BitwardenSecret{}
+			g.Expect(fixture.K8sClient.Get(fixture.Ctx, types.NamespacedName{Name: testutils.BitwardenSecretName, Namespace: namespace}, fetched)).To(Succeed())
+		}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: testutils.BitwardenSecretName, Namespace: namespace}}
+		result, err := fixture.Reconciler.Reconcile(fixture.Ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Duration(fixture.Reconciler.RefreshIntervalSeconds) * time.Second))
+
+		Eventually(func(g Gomega) {
+			k8sSecret := &corev1.Secret{}
+			g.Expect(fixture.K8sClient.Get(fixture.Ctx, types.NamespacedName{Name: testutils.SynchronizedSecretName, Namespace: namespace}, k8sSecret)).To(Succeed())
+			// Only the 3 secrets from targetProjectId should be synced
+			g.Expect(k8sSecret.Data).To(HaveLen(3))
+		}).Should(Succeed())
+	})
+
+	It("should sync all secrets when no project ID is specified", func() {
+		otherProjectId := uuid.NewString()
+		secrets := []sdk.SecretResponse{
+			{ID: uuid.NewString(), Key: "secret_0", Value: "v0", OrganizationID: fixture.OrgId, ProjectID: &targetProjectId, CreationDate: time.Now(), RevisionDate: time.Now()},
+			{ID: uuid.NewString(), Key: "secret_1", Value: "v1", OrganizationID: fixture.OrgId, ProjectID: &targetProjectId, CreationDate: time.Now(), RevisionDate: time.Now()},
+			{ID: uuid.NewString(), Key: "other_0", Value: "o0", OrganizationID: fixture.OrgId, ProjectID: &otherProjectId, CreationDate: time.Now(), RevisionDate: time.Now()},
+			{ID: uuid.NewString(), Key: "other_1", Value: "o1", OrganizationID: fixture.OrgId, ProjectID: &otherProjectId, CreationDate: time.Now(), RevisionDate: time.Now()},
+		}
+		fixture.SetupDefaultCtrlMocks(false, &sdk.SecretsSyncResponse{HasChanges: true, Secrets: secrets})
+
+		_, err := fixture.CreateDefaultAuthSecret(namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		bwSecret := &operatorsv1.BitwardenSecret{
+			ObjectMeta: metav1.ObjectMeta{Name: testutils.BitwardenSecretName, Namespace: namespace},
+			Spec: operatorsv1.BitwardenSecretSpec{
+				AuthToken:         operatorsv1.AuthToken{SecretName: testutils.AuthSecretName, SecretKey: testutils.AuthSecretKey},
+				SecretName:        testutils.SynchronizedSecretName,
+				OrganizationId:    fixture.OrgId,
+				OnlyMappedSecrets: false,
+				// No ProjectId: all secrets should be synced
+			},
+		}
+		Expect(fixture.K8sClient.Create(fixture.Ctx, bwSecret)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			fetched := &operatorsv1.BitwardenSecret{}
+			g.Expect(fixture.K8sClient.Get(fixture.Ctx, types.NamespacedName{Name: testutils.BitwardenSecretName, Namespace: namespace}, fetched)).To(Succeed())
+		}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: testutils.BitwardenSecretName, Namespace: namespace}}
+		result, err := fixture.Reconciler.Reconcile(fixture.Ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Duration(fixture.Reconciler.RefreshIntervalSeconds) * time.Second))
+
+		Eventually(func(g Gomega) {
+			k8sSecret := &corev1.Secret{}
+			g.Expect(fixture.K8sClient.Get(fixture.Ctx, types.NamespacedName{Name: testutils.SynchronizedSecretName, Namespace: namespace}, k8sSecret)).To(Succeed())
+			// All 4 secrets should be synced when no ProjectId filter is set
+			g.Expect(k8sSecret.Data).To(HaveLen(4))
+		}).Should(Succeed())
+	})
+
+	It("should create an empty K8s secret when no secrets match the specified project ID", func() {
+		otherProjectId := uuid.NewString()
+		nonMatchingProjectId := uuid.NewString()
+		secrets := []sdk.SecretResponse{
+			{ID: uuid.NewString(), Key: "secret_0", Value: "v0", OrganizationID: fixture.OrgId, ProjectID: &otherProjectId, CreationDate: time.Now(), RevisionDate: time.Now()},
+			{ID: uuid.NewString(), Key: "secret_1", Value: "v1", OrganizationID: fixture.OrgId, ProjectID: &otherProjectId, CreationDate: time.Now(), RevisionDate: time.Now()},
+		}
+		fixture.SetupDefaultCtrlMocks(false, &sdk.SecretsSyncResponse{HasChanges: true, Secrets: secrets})
+
+		_, err := fixture.CreateDefaultAuthSecret(namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		bwSecret := &operatorsv1.BitwardenSecret{
+			ObjectMeta: metav1.ObjectMeta{Name: testutils.BitwardenSecretName, Namespace: namespace},
+			Spec: operatorsv1.BitwardenSecretSpec{
+				AuthToken:         operatorsv1.AuthToken{SecretName: testutils.AuthSecretName, SecretKey: testutils.AuthSecretKey},
+				SecretName:        testutils.SynchronizedSecretName,
+				OrganizationId:    fixture.OrgId,
+				OnlyMappedSecrets: false,
+				ProjectId:         nonMatchingProjectId,
+			},
+		}
+		Expect(fixture.K8sClient.Create(fixture.Ctx, bwSecret)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			fetched := &operatorsv1.BitwardenSecret{}
+			g.Expect(fixture.K8sClient.Get(fixture.Ctx, types.NamespacedName{Name: testutils.BitwardenSecretName, Namespace: namespace}, fetched)).To(Succeed())
+		}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: testutils.BitwardenSecretName, Namespace: namespace}}
+		result, err := fixture.Reconciler.Reconcile(fixture.Ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Duration(fixture.Reconciler.RefreshIntervalSeconds) * time.Second))
+
+		Eventually(func(g Gomega) {
+			k8sSecret := &corev1.Secret{}
+			g.Expect(fixture.K8sClient.Get(fixture.Ctx, types.NamespacedName{Name: testutils.SynchronizedSecretName, Namespace: namespace}, k8sSecret)).To(Succeed())
+			// No secrets match the project filter, so the K8s secret should have no data
+			g.Expect(k8sSecret.Data).To(BeEmpty())
+		}).Should(Succeed())
+	})
+
+	It("should exclude secrets with a nil project ID when filtering by project ID", func() {
+		secrets := []sdk.SecretResponse{
+			{ID: uuid.NewString(), Key: "secret_0", Value: "v0", OrganizationID: fixture.OrgId, ProjectID: &targetProjectId, CreationDate: time.Now(), RevisionDate: time.Now()},
+			{ID: uuid.NewString(), Key: "secret_1", Value: "v1", OrganizationID: fixture.OrgId, ProjectID: nil, CreationDate: time.Now(), RevisionDate: time.Now()},
+			{ID: uuid.NewString(), Key: "secret_2", Value: "v2", OrganizationID: fixture.OrgId, ProjectID: nil, CreationDate: time.Now(), RevisionDate: time.Now()},
+		}
+		fixture.SetupDefaultCtrlMocks(false, &sdk.SecretsSyncResponse{HasChanges: true, Secrets: secrets})
+
+		_, err := fixture.CreateDefaultAuthSecret(namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		bwSecret := &operatorsv1.BitwardenSecret{
+			ObjectMeta: metav1.ObjectMeta{Name: testutils.BitwardenSecretName, Namespace: namespace},
+			Spec: operatorsv1.BitwardenSecretSpec{
+				AuthToken:         operatorsv1.AuthToken{SecretName: testutils.AuthSecretName, SecretKey: testutils.AuthSecretKey},
+				SecretName:        testutils.SynchronizedSecretName,
+				OrganizationId:    fixture.OrgId,
+				OnlyMappedSecrets: false,
+				ProjectId:         targetProjectId,
+			},
+		}
+		Expect(fixture.K8sClient.Create(fixture.Ctx, bwSecret)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			fetched := &operatorsv1.BitwardenSecret{}
+			g.Expect(fixture.K8sClient.Get(fixture.Ctx, types.NamespacedName{Name: testutils.BitwardenSecretName, Namespace: namespace}, fetched)).To(Succeed())
+		}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: testutils.BitwardenSecretName, Namespace: namespace}}
+		result, err := fixture.Reconciler.Reconcile(fixture.Ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Duration(fixture.Reconciler.RefreshIntervalSeconds) * time.Second))
+
+		Eventually(func(g Gomega) {
+			k8sSecret := &corev1.Secret{}
+			g.Expect(fixture.K8sClient.Get(fixture.Ctx, types.NamespacedName{Name: testutils.SynchronizedSecretName, Namespace: namespace}, k8sSecret)).To(Succeed())
+			// Only the 1 secret with a matching ProjectID should be synced; nil-project secrets are excluded
+			g.Expect(k8sSecret.Data).To(HaveLen(1))
+		}).Should(Succeed())
+	})
+})


### PR DESCRIPTION
## 📔 Objective

Adds support for filtering synced secrets by Bitwarden Secrets Manager project ID. Previously, the operator would sync all secrets accessible by the machine account. With this change, users can optionally set a `projectId` field on the `BitwardenSecret` CR to restrict synchronization to only the secrets belonging to a specific project.

This is useful when a machine account has access to multiple projects but a given Kubernetes namespace should only reflect the secrets of one of them.

### Changes

- **bitwardensecret_types.go**: Added optional `ProjectId string` field to `BitwardenSecretSpec`. When empty, behavior is unchanged (all accessible secrets are synced).
- **bitwardensecret_controller.go**: Extended `PullSecretManagerSecretDeltas` with a `projectId` parameter. After the `Sync` call, secrets are filtered client-side by matching `SecretResponse.ProjectID`. The `Reconcile` loop passes `bwSecret.Spec.ProjectId` to this function.
- **config/crd/bases/k8s.bitwarden.com_bitwardensecrets.yaml**: Added `projectId` field to the CRD OpenAPI schema.
- **internal/controller/test/reconciler_project_filter_test.go**: Added integration tests covering the four key filtering scenarios:
  - Only secrets belonging to the specified project ID are synced.
  - All secrets are synced when no project ID is set (backwards-compatible).
  - An empty K8s secret is created when no secrets match the project ID.
  - Secrets with a `nil` project ID are excluded when a project filter is active.

### Usage

```yaml
spec:
  organizationId: "YOUR-ORG-UUID"
  projectId: "YOUR-PROJECT-UUID"  # optional
  secretName: my-k8s-secret
  useSecretNames: true
  authToken:
    secretName: bw-auth-token
    secretKey: token
```