### PR TITLE
fix: reconciliation issues

### DIFF
--- a/internal/controller/bitwardensecret_controller.go
+++ b/internal/controller/bitwardensecret_controller.go
@@ -82,7 +82,7 @@ func (r *BitwardenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		//Error was due to missing item
 		if k8serrors.IsNotFound(err) {
 			logger.Info(fmt.Sprintf("%s/%s was deleted.", req.NamespacedName.Namespace, req.Name))
-			return ctrl.Result{}, err
+			return ctrl.Result{}, nil
 		}
 
 		logErr := r.LogError(logger, ctx, bwSecret, err, "Error looking up BitwardenSecret")
@@ -100,8 +100,18 @@ func (r *BitwardenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	lastSync := bwSecret.Status.LastSuccessfulSyncTime
 
-	if !lastSync.IsZero() && time.Now().UTC().Before(lastSync.Time.Add(time.Duration(r.RefreshIntervalSeconds)*time.Second)) {
-		return ctrl.Result{}, nil
+	if !lastSync.IsZero() {
+		next := lastSync.Time.Add(time.Duration(r.RefreshIntervalSeconds) * time.Second)
+		if time.Now().UTC().Before(next) {
+			return ctrl.Result{RequeueAfter: time.Until(next)}, nil
+		}
+	}
+
+	// If the K8s Secret doesn't exist, force a full sync so it gets recreated
+	// regardless of whether Bitwarden reports changes since the last sync.
+	existingK8sSecret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: bwSecret.Spec.SecretName, Namespace: req.NamespacedName.Namespace}, existingK8sSecret); err != nil && k8serrors.IsNotFound(err) {
+		lastSync = metav1.Time{}
 	}
 
 	message := fmt.Sprintf("Syncing  %s/%s", req.NamespacedName.Namespace, req.Name)


### PR DESCRIPTION
## 📔 Objective

Fix three bugs in the BitwardenSecret reconciler that caused secrets to stop syncing after the first reconciliation cycle, deleted K8s Secrets not being recreated, and spurious error logs on resource deletion.

Bug 1 — Reconciler stops running after first successful sync

After a successful sync, LogCompletion updates the BitwardenSecret status, which triggers an immediate re-reconciliation. That reconciliation hit the interval guard and returned ctrl.Result{} (no requeue), effectively cancelling the RequeueAfter timer scheduled by the successful sync. As a result, the controller would sync once on resource creation and then never again.

Fix: the interval guard now returns ctrl.Result{RequeueAfter: time.Until(next)} instead of ctrl.Result{}, so every reconciliation within the interval reschedules itself for the remaining time.

Bug 2 — Manually deleted K8s Secret is never recreated

The logic to create or patch the K8s Secret only runs when HasChanges = true is returned by the Bitwarden Sync API. If the K8s Secret was deleted but nothing had changed in Bitwarden, HasChanges = false and the secret was never recreated.

Fix: before calling the Bitwarden API, check if the target K8s Secret exists. If it does not, reset lastSync to zero to force a full sync, which always returns HasChanges = true and all secrets, triggering recreation.

Bug 3 — Spurious "Reconciler error" log on BitwardenSecret deletion

When a BitwardenSecret was deleted, the controller correctly logged the deletion but then returned the NotFound error to controller-runtime, which logged it as a reconciler error. Deletion is expected behaviour and should not produce an error.

Fix: return nil instead of err when the resource is not found.
