### PR TITLE
fix: update renovate minutes value to use wildcard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>bitwarden/renovate-config"],
   "timezone": "America/Chicago",
-  "schedule": ["0 0-4 1-7 2/2 1"],
+  "schedule": ["* 0-4 1-7 2/2 1"],
   "enabledManagers": [
     "cargo",
     "devcontainer",


### PR DESCRIPTION
## 📔 Objective

> 0 in as the minutes value apparently does **not** work for cron formatting renovate schedule. Update to use the recommended wildcard value.
