### PR TITLE
fix: secrets reconciliation re-queuing issues

### DIFF
--- a/internal/controller/bitwardensecret_controller.go
+++ b/internal/controller/bitwardensecret_controller.go
@@ -99,9 +99,15 @@ func (r *BitwardenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	lastSync := bwSecret.Status.LastSuccessfulSyncTime
+	nextSync := lastSync.Time.Add(time.Duration(r.RefreshIntervalSeconds) * time.Second)
 
-	if !lastSync.IsZero() && time.Now().UTC().Before(lastSync.Time.Add(time.Duration(r.RefreshIntervalSeconds)*time.Second)) {
-		return ctrl.Result{}, nil
+	if !lastSync.IsZero() && time.Now().UTC().Before(nextSync) {
+		remaining := time.Until(nextSync)
+		logger.Info(fmt.Sprintf("Skipping sync for %s/%s — last sync was %s, next sync in %s",
+			req.NamespacedName.Namespace, req.Name, lastSync.Time.Format("15:04:05"), remaining.Round(time.Second)))
+		return ctrl.Result{
+			RequeueAfter: remaining,
+		}, nil
 	}
 
 	message := fmt.Sprintf("Syncing  %s/%s", req.NamespacedName.Namespace, req.Name)

--- a/internal/controller/bitwardensecret_controller.go
+++ b/internal/controller/bitwardensecret_controller.go
@@ -82,7 +82,7 @@ func (r *BitwardenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		//Error was due to missing item
 		if k8serrors.IsNotFound(err) {
 			logger.Info(fmt.Sprintf("%s/%s was deleted.", req.NamespacedName.Namespace, req.Name))
-			return ctrl.Result{}, err
+			return ctrl.Result{}, nil
 		}
 
 		logErr := r.LogError(logger, ctx, bwSecret, err, "Error looking up BitwardenSecret")
@@ -108,6 +108,13 @@ func (r *BitwardenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{
 			RequeueAfter: remaining,
 		}, nil
+	}
+
+	// If the K8s Secret doesn't exist, force a full sync so it gets recreated
+	// regardless of whether Bitwarden reports changes since the last sync.
+	existingK8sSecret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: bwSecret.Spec.SecretName, Namespace: req.NamespacedName.Namespace}, existingK8sSecret); err != nil && k8serrors.IsNotFound(err) {
+		lastSync = metav1.Time{}
 	}
 
 	message := fmt.Sprintf("Syncing  %s/%s", req.NamespacedName.Namespace, req.Name)

--- a/internal/controller/bitwardensecret_controller.go
+++ b/internal/controller/bitwardensecret_controller.go
@@ -85,10 +85,10 @@ func (r *BitwardenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, nil
 		}
 
-		logErr := r.LogError(logger, ctx, bwSecret, err, "Error looking up BitwardenSecret")
+		logger.Error(err, "Error looking up BitwardenSecret", "namespace", req.NamespacedName.Namespace, "name", req.Name)
 
 		//Other lookup error
-		return ctrl.Result{RequeueAfter: time.Duration(r.RefreshIntervalSeconds) * time.Second}, logErr
+		return ctrl.Result{RequeueAfter: time.Duration(r.RefreshIntervalSeconds) * time.Second}, err
 	}
 
 	// Validate that useSecretNames and onlyMappedSecrets are not both enabled

--- a/internal/controller/bitwardensecret_controller.go
+++ b/internal/controller/bitwardensecret_controller.go
@@ -99,6 +99,14 @@ func (r *BitwardenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	lastSync := bwSecret.Status.LastSuccessfulSyncTime
+
+	// If the K8s Secret doesn't exist, force a full sync so it gets recreated
+	// regardless of whether Bitwarden reports changes since the last sync.
+	existingK8sSecret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: bwSecret.Spec.SecretName, Namespace: req.NamespacedName.Namespace}, existingK8sSecret); err != nil && k8serrors.IsNotFound(err) {
+		lastSync = metav1.Time{}
+	}
+
 	nextSync := lastSync.Time.Add(time.Duration(r.RefreshIntervalSeconds) * time.Second)
 
 	if !lastSync.IsZero() && time.Now().UTC().Before(nextSync) {
@@ -108,13 +116,6 @@ func (r *BitwardenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{
 			RequeueAfter: remaining,
 		}, nil
-	}
-
-	// If the K8s Secret doesn't exist, force a full sync so it gets recreated
-	// regardless of whether Bitwarden reports changes since the last sync.
-	existingK8sSecret := &corev1.Secret{}
-	if err := r.Get(ctx, types.NamespacedName{Name: bwSecret.Spec.SecretName, Namespace: req.NamespacedName.Namespace}, existingK8sSecret); err != nil && k8serrors.IsNotFound(err) {
-		lastSync = metav1.Time{}
 	}
 
 	message := fmt.Sprintf("Syncing  %s/%s", req.NamespacedName.Namespace, req.Name)

--- a/internal/controller/test/reconciler_error_handling_test.go
+++ b/internal/controller/test/reconciler_error_handling_test.go
@@ -1,7 +1,6 @@
 package controller_test
 
 import (
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -52,9 +51,8 @@ var _ = Describe("BitwardenSecret Reconciler - Error Handling Tests", Ordered, f
 
 		result, err := fixture.Reconciler.Reconcile(fixture.Ctx, req)
 
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("\"%s\" not found", testutils.BitwardenSecretName)))
-		Expect(result.Requeue).To(BeFalse())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
 	})
 
 	It("should handle a generic error during BitwardenSecret retrieval", func() {

--- a/internal/controller/test/reconciler_success_test.go
+++ b/internal/controller/test/reconciler_success_test.go
@@ -78,43 +78,29 @@ var _ = Describe("BitwardenSecret Reconciler - Success Tests", Ordered, func() {
 		}).Should(Succeed())
 	})
 
-	// //This test misbehaves with the following error.  There's no rational reason for this to happen, so we'll leave it to the
-	// //end user to figure out if this test is relevant to their needs.
-	// //Message: "Operation cannot be fulfilled on bitwardensecrets.k8s.bitwarden.com \"bw-secret\": the object has been modified; please apply your changes to the latest version and try again",
-	// It("should skip reconciliation when last sync is within refresh interval", func() {
-	// 	fixture.SetupDefaultCtrlMocks(false, nil)
+	It("should skip reconciliation when last sync is within refresh interval", func() {
+		fixture.SetupDefaultCtrlMocks(false, nil)
 
-	// 	_, err := fixture.CreateDefaultAuthSecret(namespace)
-	// 	Expect(err).NotTo(HaveOccurred())
+		_, err := fixture.CreateDefaultAuthSecret(namespace)
+		Expect(err).NotTo(HaveOccurred())
 
-	// 	bwSecret, err := fixture.CreateDefaultBitwardenSecret(namespace, fixture.SecretMap)
-	// 	Expect(err).NotTo(HaveOccurred())
-	// 	Expect(bwSecret).NotTo(BeNil())
+		_, err = fixture.CreateDefaultBitwardenSecret(namespace, fixture.SecretMap)
+		Expect(err).NotTo(HaveOccurred())
 
-	// 	// Update status with LastSuccessfulSyncTime, retrying on conflicts
-	// 	syncTime := time.Now().UTC()
-	// 	Eventually(func(g Gomega) {
-	// 		// Fetch the latest version of bwSecret (use cached client for Get)
-	// 		latestBwSecret := &operatorsv1.BitwardenSecret{}
-	// 		err := fixture.K8sClient.Get(fixture.Ctx, types.NamespacedName{Name: testutils.BitwardenSecretName, Namespace: namespace}, latestBwSecret)
-	// 		GinkgoWriter.Printf("Fetched BitwardenSecret %s/%s, ResourceVersion: %s, err: %v\n", namespace, testutils.BitwardenSecretName, latestBwSecret.ResourceVersion, err)
-	// 		g.Expect(err).Should(Succeed())
+		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: testutils.BitwardenSecretName, Namespace: namespace}}
 
-	// 		// Update status
-	// 		latestBwSecret.Status = operatorsv1.BitwardenSecretStatus{
-	// 			LastSuccessfulSyncTime: metav1.Time{Time: syncTime},
-	// 		}
-	// 		err = fixture.K8sClient.Status().Update(fixture.Ctx, latestBwSecret)
-	// 		GinkgoWriter.Printf("Status update for %s/%s, ResourceVersion: %s, err: %v\n", namespace, testutils.BitwardenSecretName, latestBwSecret.ResourceVersion, err)
-	// 		g.Expect(err).Should(Succeed())
-	// 	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+		// First reconcile: performs the actual sync and sets LastSuccessfulSyncTime
+		result, err := fixture.Reconciler.Reconcile(fixture.Ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Duration(fixture.Reconciler.RefreshIntervalSeconds) * time.Second))
 
-	// 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: testutils.BitwardenSecretName, Namespace: namespace}}
-
-	// 	result, err := fixture.Reconciler.Reconcile(fixture.Ctx, req)
-	// 	Expect(err).NotTo(HaveOccurred())
-	// 	Expect(result).To(Equal(reconcile.Result{}))
-	// })
+		// Second reconcile: should skip because last sync is within refresh interval
+		result, err = fixture.Reconciler.Reconcile(fixture.Ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		fullInterval := time.Duration(fixture.Reconciler.RefreshIntervalSeconds) * time.Second
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+		Expect(result.RequeueAfter).To(BeNumerically("<=", fullInterval))
+	})
 
 	It("should skip sync when no changes from Bitwarden API", func() {
 		// Override mocks to return no changes

--- a/internal/controller/test/reconciler_success_test.go
+++ b/internal/controller/test/reconciler_success_test.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -100,6 +101,50 @@ var _ = Describe("BitwardenSecret Reconciler - Success Tests", Ordered, func() {
 		fullInterval := time.Duration(fixture.Reconciler.RefreshIntervalSeconds) * time.Second
 		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
 		Expect(result.RequeueAfter).To(BeNumerically("<=", fullInterval))
+	})
+
+	It("should recreate the K8s Secret when it is deleted out-of-band", func() {
+		fixture.SetupDefaultCtrlMocks(false, nil)
+
+		_, err := fixture.CreateDefaultAuthSecret(namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = fixture.CreateDefaultBitwardenSecret(namespace, fixture.SecretMap)
+		Expect(err).NotTo(HaveOccurred())
+
+		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: testutils.BitwardenSecretName, Namespace: namespace}}
+
+		// First reconcile: performs the sync and creates the K8s Secret
+		result, err := fixture.Reconciler.Reconcile(fixture.Ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Duration(fixture.Reconciler.RefreshIntervalSeconds) * time.Second))
+
+		// Verify the K8s Secret was created
+		createdSecret := &corev1.Secret{}
+		Eventually(func(g Gomega) {
+			g.Expect(fixture.K8sClient.Get(fixture.Ctx, types.NamespacedName{Name: testutils.SynchronizedSecretName, Namespace: namespace}, createdSecret)).Should(Succeed())
+		}).Should(Succeed())
+
+		// Delete the K8s Secret out-of-band (simulating manual deletion)
+		Expect(fixture.K8sClient.Delete(fixture.Ctx, createdSecret)).To(Succeed())
+
+		// Wait for deletion to propagate
+		Eventually(func(g Gomega) {
+			err := fixture.K8sClient.Get(fixture.Ctx, types.NamespacedName{Name: testutils.SynchronizedSecretName, Namespace: namespace}, &corev1.Secret{})
+			g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		}).Should(Succeed())
+
+		// Second reconcile: should force a full sync and recreate the K8s Secret
+		result, err = fixture.Reconciler.Reconcile(fixture.Ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Duration(fixture.Reconciler.RefreshIntervalSeconds) * time.Second))
+
+		// Verify the K8s Secret was recreated
+		recreatedSecret := &corev1.Secret{}
+		Eventually(func(g Gomega) {
+			g.Expect(fixture.K8sClient.Get(fixture.Ctx, types.NamespacedName{Name: testutils.SynchronizedSecretName, Namespace: namespace}, recreatedSecret)).Should(Succeed())
+			g.Expect(recreatedSecret.Data).NotTo(BeEmpty())
+		}).Should(Succeed())
 	})
 
 	It("should skip sync when no changes from Bitwarden API", func() {


### PR DESCRIPTION
## 🎟️ Tracking

- https://bitwarden.atlassian.net/browse/SM-1956
- https://bitwarden.atlassian.net/browse/SM-1957

## 📔 Objective

Tweak some existing community PRs (https://github.com/bitwarden/sm-kubernetes/pull/132 and https://github.com/bitwarden/sm-kubernetes/pull/152) and add additional test coverage where applicable.

The original controller had two re-queuing bugs:

1. Secrets never re-synced after the first successful reconciliation. The early-return path in `Reconcile` (when `lastSync` is still within the refresh interval) returned `ctrl.Result{}`, which tells controller-runtime "no more work, don't re-queue." After the first sync, secrets would only sync again if the `BitwardenSecret` CR was modified externally. Fixed by returning `ctrl.Result{RequeueAfter: remaining}` so the reconciler is reliably re-invoked at the configured interval.

2. Deleted `BitwardenSecret` kept retrying. When the BitwardenSecret CR was deleted, the reconciler returned `ctrl.Result{}, err`. Returning a non-nil error with an empty result causes controller-runtime to keep re-queuing the request indefinitely. Fixed by returning `ctrl.Result{}, nil`.

3. K8s Secret deleted out-of-band was never recreated. If the managed `corev1.Secret` was manually deleted, the reconciler had no mechanism to recreate it on the next cycle. Fixed by checking whether the K8s Secret exists before the sync-skip decision; if it's missing, `lastSync` is zeroed to force a full re-sync regardless of the delta response.

Additionally, three code quality issues identified during review were addressed:

- Stale `nextSync` variable ordering. `nextSync` was computed before the K8s Secret existence check could zero `lastSync`, making the variable inconsistent. Reordered so the check happens first.
- `LogError` called with empty object. On a generic lookup error, `bwSecret` is a zero-value struct. `LogError` would attempt to re-fetch and update status on it, failing harmlessly but wastefully. Changed to a direct `logger.Error` call.
- Missing test for K8s Secret re-creation. Added an integration test that deletes the managed secret out-of-band and verifies the reconciler recreates it.


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
